### PR TITLE
Add method with extra return type 

### DIFF
--- a/duckduckgo/__init__.py
+++ b/duckduckgo/__init__.py
@@ -7,13 +7,14 @@
 # See LICENSE for terms of usage, modification and redistribution.
 
 from ._version import __version__
-from .query import DuckDuckGoError, query, zci
+from .query import DuckDuckGoError, query, zci, zci_extra
 from .ratelimit import Ratelimit
 
 __all__ = [
     'DuckDuckGoError',
     'query',
     'zci',
+    'zci_extra',
     'Ratelimit',
     '__version__',
 ]

--- a/duckduckgo/__init__.py
+++ b/duckduckgo/__init__.py
@@ -7,14 +7,15 @@
 # See LICENSE for terms of usage, modification and redistribution.
 
 from ._version import __version__
-from .query import DuckDuckGoError, query, zci, zci_extra
+from .query import DuckDuckGoError, query, zci_with_result, zci_with_type, zci
 from .ratelimit import Ratelimit
 
 __all__ = [
     'DuckDuckGoError',
     'query',
+    'zci_with_result',
+    'zci_with_type',
     'zci',
-    'zci_extra',
     'Ratelimit',
     '__version__',
 ]

--- a/duckduckgo/query.py
+++ b/duckduckgo/query.py
@@ -42,10 +42,10 @@ async def query(q: str,
     Any other keyword arguments are passed directly to DuckDuckGo as URL params.
     """
 
-    logger.info(f"Performing DDG query: '{q}'")
-    logger.debug(f"Safesearch: {safesearch}")
-    logger.debug(f"HTML: {html}")
-    logger.debug(f"Meanings: {meanings}")
+    logger.info("Performing DDG query: '%s'", query)
+    logger.debug("Safesearch: %s", safesearch)
+    logger.debug("HTML: %s", html)
+    logger.debug("Meanings: %s", meanings)
 
     safesearch = '1' if safesearch else '-1'
     html = '0' if html else '1'
@@ -59,19 +59,19 @@ async def query(q: str,
         'd': meanings,
     }
     params.update(kwargs)
-    logger.debug(f"Full parameters: {params}")
+    logger.debug("Full parameters: %s", params)
 
     encparams = urllib.parse.urlencode(params)
     url = f'http://api.duckduckgo.com/?{encparams}'
 
-    logger.debug(f"Full request url: {url}")
+    logger.debug("Full request url: %s", url)
     async with aiohttp.ClientSession() as cs:
         async with cs.get(url, headers={'User-Agent': useragent}) as req:
             response = await req.json(content_type='application/x-javascript')
             if response is None:
                 raise DuckDuckGoError("Invalid JSON response")
 
-    logger.debug(f"Response is {response}")
+    logger.debug("Response is %s", response)
     return Results(response)
 
 
@@ -87,9 +87,9 @@ async def zci_with_result(q: str,
     if it cannot find anything. Returns tuple with result string and original DDG
     results.'''
 
-    logger.info(f"Performing DDG ZCI: '{q}'")
-    logger.debug(f"Web fallback: {web_fallback}")
-    logger.debug(f"Use URLs: {urls}")
+    logger.info("Performing DDG ZCI: '%s'", q)
+    logger.debug("Web fallback: %s", web_fallback)
+    logger.debug("Use URLs: %s", urls)
 
     ddg = await query(f'\\{q}', **kwargs)
     response = ''
@@ -109,12 +109,13 @@ async def zci_with_result(q: str,
 
         if not result:
             continue
-        elif result.text:
-            logger.debug(f"Result has text: {result.text}")
+
+        if result.text:
+            logger.debug("Result has text: %s", result.text)
             response = result.text
 
             if getattr(result, 'url', None) and urls:
-                logger.debug(f"Result has url: {result.url}")
+                logger.debug("Result has url: %s", result.url)
                 response += f' ({result.url})'
 
             break
@@ -130,7 +131,7 @@ async def zci_with_result(q: str,
         logger.info("No results!")
         response = 'Sorry, no results.'
 
-    logger.debug(f"Final response: {response!r}")
+    logger.debug("Final response: %s", response)
     return [response, ddg]
 
 async def zci(q: str,
@@ -144,7 +145,7 @@ async def zci(q: str,
     passed to query. This method will fall back to 'Sorry, no results.'
     if it cannot find anything. Only returns the result string.'''
 
-    (result, ddg) = await zci_with_result(q, web_fallback, priority, urls, **kwargs)[0]
+    (result, _) = await zci_with_result(q, web_fallback, priority, urls, **kwargs)[0]
     return result
 
 async def zci_with_type(q: str,

--- a/duckduckgo/query.py
+++ b/duckduckgo/query.py
@@ -129,3 +129,67 @@ async def zci(q: str,
 
     logger.debug(f"Final response: {response!r}")
     return response
+
+async def zci_extra(q: str,
+        web_fallback: bool = True,
+        priority: Tuple[str] = DEFAULT_PRIORITIES,
+        urls: bool = True,
+        **kwargs) -> Tuple[str, bool, bool]:
+    '''A helper method to get a single (and hopefully the best) ZCI result.
+    priority=list can be used to set the order in which fields will be checked for answers.
+    Use web_fallback=True to fall back to grabbing the first web result.
+    passed to query. This method will fall back to 'Sorry, no results.'
+    if it cannot find anything. Returns a tuple with [result, result_found, is_fallback] which
+    allows to determine how the result was retrieved.'''
+
+    logger.info(f"Performing DDG ZCI: '{q}'")
+    logger.debug(f"Web fallback: {web_fallback}")
+    logger.debug(f"Use URLs: {urls}")
+
+    ddg = await query(f'\\{q}', **kwargs)
+    response = ''
+    found = True
+    is_fallback = False
+
+    for p in priority:
+        ps = p.split('.')
+        type = ps[0]
+        index = int(ps[1]) if len(ps) > 1 else None
+
+        result = getattr(ddg, type)
+        if index is not None:
+            if not hasattr(result, '__getitem__'):
+                logger.error("Result is not indexable!")
+                raise TypeError(f'{type} field is not indexable')
+
+            result = result[index] if len(result) > index else None
+
+        if not result:
+            continue
+        elif result.text:
+            logger.debug(f"Result has text: {result.text}")
+            response = result.text
+
+            if getattr(result, 'url', None) and urls:
+                logger.debug(f"Result has url: {result.url}")
+                response += f' ({result.url})'
+
+            break
+
+    # If there still isn't anything, try to get the first web result
+    logger.debug("Trying web fallback...")
+    if not response and web_fallback:
+        if ddg.redirect.url:
+            is_fallback = True
+            found = True
+            response = ddg.redirect.url
+
+    # Final fallback
+    logger.info("No results!")
+    if not response:
+        found = False
+        is_fallback = True
+        response = 'Sorry, no results.'
+
+    logger.debug(f"Final response: {response!r}")
+    return (response, found, is_fallback)

--- a/duckduckgo/query.py
+++ b/duckduckgo/query.py
@@ -135,12 +135,12 @@ async def zci_extra(q: str,
         web_fallback: bool = True,
         priority: Tuple[str] = DEFAULT_PRIORITIES,
         urls: bool = True,
-        **kwargs) -> Tuple[str, bool, str]:
+        **kwargs) -> Tuple[str, str]:
     '''A helper method to get a single (and hopefully the best) ZCI result.
     priority=list can be used to set the order in which fields will be checked for answers.
     Use web_fallback=True to fall back to grabbing the first web result.
     passed to query. This method will fall back to 'Sorry, no results.'
-    if it cannot find anything. Returns a tuple with [result, result_found, result_type] which
+    if it cannot find anything. Returns a tuple with [result, result_type] which
     allows to determine how the result was retrieved.'''
 
     logger.info(f"Performing DDG ZCI: '{q}'")
@@ -149,8 +149,7 @@ async def zci_extra(q: str,
 
     ddg = await query(f'\\{q}', **kwargs)
     response = ''
-    found = True
-    result_type = ''
+    result_type = getattr(ddg, 'type', '')
 
     for p in priority:
         ps = p.split('.')
@@ -181,15 +180,12 @@ async def zci_extra(q: str,
     if not response and web_fallback:
         logger.debug("Trying web fallback...")
         if ddg.redirect.url:
-            found = True
-            result_type = ddg.type
             response = ddg.redirect.url
 
     # Final fallback
     if not response:
         logger.info("No results!")
-        found = False
         response = 'Sorry, no results.'
 
     logger.debug(f"Final response: {response!r}")
-    return (response, found, result_type)
+    return (response, result_type)

--- a/duckduckgo/query.py
+++ b/duckduckgo/query.py
@@ -70,7 +70,7 @@ async def query(q: str,
             if response is None:
                 raise DuckDuckGoError("Invalid JSON response")
 
-    logger.debug("Response is {response}")
+    logger.debug(f"Response is {response}")
     return Results(response)
 
 async def zci(q: str,

--- a/duckduckgo/query.py
+++ b/duckduckgo/query.py
@@ -84,8 +84,8 @@ async def zci_with_result(q: str,
     priority=list can be used to set the order in which fields will be checked for answers.
     Use web_fallback=True to fall back to grabbing the first web result.
     passed to query. This method will fall back to 'Sorry, no results.'
-    if it cannot find anything. Retruns tuple with result string and original DDG
-    Results.'''
+    if it cannot find anything. Returns tuple with result string and original DDG
+    results.'''
 
     logger.info(f"Performing DDG ZCI: '{q}'")
     logger.debug(f"Web fallback: {web_fallback}")
@@ -142,7 +142,7 @@ async def zci(q: str,
     priority=list can be used to set the order in which fields will be checked for answers.
     Use web_fallback=True to fall back to grabbing the first web result.
     passed to query. This method will fall back to 'Sorry, no results.'
-    if it cannot find anything. Returns just result string.'''
+    if it cannot find anything. Only returns the result string.'''
 
     (result, ddg) = await zci_with_result(q, web_fallback, priority, urls, **kwargs)[0]
     return result


### PR DESCRIPTION
Added a clone of `zci` method that additionally returns a tuple with extra information about what type of result it was. As per ddg api docs:
```
Type: response category, i.e. A (article), D (disambiguation), C (category), N (name), E (exclusive), or nothing.
```

Didn't want to modify `zci` method as this is breaking change so if something is using the library it would end badly.

Also has some unrelated changes that fix logging and what not.